### PR TITLE
Add the testsuite to the phpunit command in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,5 +77,5 @@ You're ready to go! Visit Ping CRM in your browser, and login with:
 To run the Ping CRM tests, run:
 
 ```
-phpunit
+phpunit --testsuite=Feature
 ```


### PR DESCRIPTION
Without the `--testsuite` switch the raw command fails with :
`Test directory ".../pingcrm/./tests/Unit" not found`